### PR TITLE
Use CMS-agnostic permission checking method

### DIFF
--- a/casepermission.php
+++ b/casepermission.php
@@ -154,7 +154,7 @@ function casepermission_civicrm_selectWhereClause($entity, &$clauses) {
     foreach($caseTypes['values'] as $caseTypeId => $caseType) {
       $caseTypeName = $caseType['name'];
       $permission = 'access cases of type '.$caseTypeName;
-      $access = user_access($permission);
+      $access = CRM_Core_Permission::check($permission);
       if ($access) {
         $extra[] = (int)$caseType['id'];
       }


### PR DESCRIPTION
As is, this extension won't work on Civi installations on D9 or WordPress. This PR refactors usage of the user_access() function towards using CRM_Core_Permission::check().